### PR TITLE
Timestamp fixes

### DIFF
--- a/internal/analysis/service.go
+++ b/internal/analysis/service.go
@@ -19,12 +19,34 @@ func NewService(pipeline *Pipeline, repository core.ReportRepository) *Service {
 }
 
 func (s *Service) Analyze(ctx context.Context, report *core.TestReport) (*core.AnalysisResult, error) {
+	result := s.pipeline.Process(ctx, report)
+
 	if err := s.repository.Store(ctx, report); err != nil {
 		return nil, err
 	}
 
-	result := s.pipeline.Process(ctx, report)
+	if err := s.recordFingerprints(ctx, report, result); err != nil {
+		return nil, err
+	}
+
 	return result, nil
+}
+
+func (s *Service) recordFingerprints(ctx context.Context, report *core.TestReport, result *core.AnalysisResult) error {
+	for _, failedTest := range result.FailedTests {
+		if failedTest.HistoricalContext == nil || failedTest.HistoricalContext.ErrorFingerprint == "" {
+			continue
+		}
+		err := s.repository.UpsertErrorFingerprint(ctx,
+			failedTest.HistoricalContext.ErrorFingerprint,
+			failedTest.NormalizedTrace,
+			report.Timestamp,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Service) ReAnalyze(ctx context.Context, report *core.TestReport) (*core.AnalysisResult, error) {

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -1,0 +1,134 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sift/internal/core"
+)
+
+type callRecordingRepo struct {
+	calls        []string
+	upsertCount  int
+	storedReport *core.TestReport
+}
+
+func (r *callRecordingRepo) Store(ctx context.Context, report *core.TestReport) error {
+	r.calls = append(r.calls, "store")
+	r.storedReport = report
+	return nil
+}
+
+func (r *callRecordingRepo) GetByID(ctx context.Context, id string) (*core.TestReport, error) {
+	return nil, nil
+}
+
+func (r *callRecordingRepo) GetByTimeRange(ctx context.Context, start, end time.Time) ([]*core.TestReport, error) {
+	return nil, nil
+}
+
+func (r *callRecordingRepo) GetFailureHistory(ctx context.Context, testName string, limit int) ([]*core.TestReport, error) {
+	return nil, nil
+}
+
+func (r *callRecordingRepo) GetTestFailureCounts(ctx context.Context, testName string, since time.Time, excludeReportID string) (int, error) {
+	return 0, nil
+}
+
+func (r *callRecordingRepo) GetTestLastSuccess(ctx context.Context, testName string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (r *callRecordingRepo) UpsertErrorFingerprint(ctx context.Context, fingerprint string, normalizedTrace string, timestamp time.Time) error {
+	r.calls = append(r.calls, "upsert_fingerprint")
+	r.upsertCount++
+	return nil
+}
+
+func (r *callRecordingRepo) GetErrorFingerprint(ctx context.Context, fingerprint string) (int, time.Time, time.Time, error) {
+	return 0, time.Time{}, time.Time{}, nil
+}
+
+func (r *callRecordingRepo) Count(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (r *callRecordingRepo) Delete(ctx context.Context, id string) error {
+	return nil
+}
+
+type markerStage struct {
+	repo *callRecordingRepo
+}
+
+func (s *markerStage) Name() string {
+	return "marker"
+}
+
+func (s *markerStage) Process(ctx context.Context, report *core.TestReport, result *core.AnalysisResult) {
+	s.repo.calls = append(s.repo.calls, "pipeline")
+	result.FailedTests = append(result.FailedTests, core.FailedTestInfo{
+		Name:            "testFail",
+		Classname:       "Sample",
+		NormalizedTrace: "trace",
+		HistoricalContext: &core.HistoricalContext{
+			ErrorFingerprint: "abc123",
+		},
+	})
+}
+
+func newTestService(repo *callRecordingRepo) *Service {
+	pipeline := NewPipeline(&markerStage{repo: repo})
+	return NewService(pipeline, repo)
+}
+
+func TestAnalyzeRunsPipelineBeforeStore(t *testing.T) {
+	repo := &callRecordingRepo{}
+	service := newTestService(repo)
+
+	report := &core.TestReport{ID: "r1", Timestamp: time.Now()}
+	if _, err := service.Analyze(context.Background(), report); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"pipeline", "store", "upsert_fingerprint"}
+	if len(repo.calls) != len(want) {
+		t.Fatalf("expected calls %v, got %v", want, repo.calls)
+	}
+	for i, call := range want {
+		if repo.calls[i] != call {
+			t.Fatalf("expected calls %v, got %v", want, repo.calls)
+		}
+	}
+}
+
+func TestAnalyzePersistsFingerprintsOnce(t *testing.T) {
+	repo := &callRecordingRepo{}
+	service := newTestService(repo)
+
+	report := &core.TestReport{ID: "r1", Timestamp: time.Now()}
+	if _, err := service.Analyze(context.Background(), report); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if repo.upsertCount != 1 {
+		t.Errorf("expected 1 fingerprint upsert, got %d", repo.upsertCount)
+	}
+}
+
+func TestReAnalyzeDoesNotWrite(t *testing.T) {
+	repo := &callRecordingRepo{}
+	service := newTestService(repo)
+
+	report := &core.TestReport{ID: "r1", Timestamp: time.Now()}
+	if _, err := service.ReAnalyze(context.Background(), report); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, call := range repo.calls {
+		if call == "store" || call == "upsert_fingerprint" {
+			t.Errorf("expected no writes during re-analysis, got call %q", call)
+		}
+	}
+}

--- a/internal/analysis/stages/enrich_history.go
+++ b/internal/analysis/stages/enrich_history.go
@@ -24,9 +24,11 @@ func (s *EnrichHistoryStage) Process(ctx context.Context, report *core.TestRepor
 		return
 	}
 
-	now := time.Now()
-	oneDayAgo := now.Add(-24 * time.Hour)
-	sevenDaysAgo := now.Add(-7 * 24 * time.Hour)
+	asOf := report.Timestamp
+	oneDayAgo := asOf.Add(-24 * time.Hour)
+	sevenDaysAgo := asOf.Add(-7 * 24 * time.Hour)
+
+	totalReports, _ := s.repo.Count(ctx)
 
 	for i := range result.FailedTests {
 		failedTest := &result.FailedTests[i]
@@ -35,12 +37,12 @@ func (s *EnrichHistoryStage) Process(ctx context.Context, report *core.TestRepor
 			failedTest.HistoricalContext = &core.HistoricalContext{}
 		}
 
-		count24h, err := s.repo.GetTestFailureCounts(ctx, failedTest.Name, oneDayAgo)
+		count24h, err := s.repo.GetTestFailureCounts(ctx, failedTest.Name, oneDayAgo, report.ID)
 		if err == nil {
 			failedTest.HistoricalContext.FailureCount24h = count24h
 		}
 
-		count7d, err := s.repo.GetTestFailureCounts(ctx, failedTest.Name, sevenDaysAgo)
+		count7d, err := s.repo.GetTestFailureCounts(ctx, failedTest.Name, sevenDaysAgo, report.ID)
 		if err == nil {
 			failedTest.HistoricalContext.FailureCount7d = count7d
 		}
@@ -59,7 +61,6 @@ func (s *EnrichHistoryStage) Process(ctx context.Context, report *core.TestRepor
 			}
 		}
 
-		totalReports, _ := s.repo.Count(ctx)
 		if totalReports > 0 {
 			failureReports, _ := s.repo.GetFailureHistory(ctx, failedTest.Name, int(totalReports))
 			passCount := int(totalReports) - len(failureReports)

--- a/internal/analysis/stages/fingerprint.go
+++ b/internal/analysis/stages/fingerprint.go
@@ -22,12 +22,10 @@ var normalizationPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\s+`),
 }
 
-type FingerprintStage struct {
-	repo core.ReportRepository
-}
+type FingerprintStage struct{}
 
-func NewFingerprintStage(repo core.ReportRepository) *FingerprintStage {
-	return &FingerprintStage{repo: repo}
+func NewFingerprintStage() *FingerprintStage {
+	return &FingerprintStage{}
 }
 
 func (s *FingerprintStage) Name() string {
@@ -45,16 +43,12 @@ func (s *FingerprintStage) Process(ctx context.Context, report *core.TestReport,
 		}
 
 		normalized := NormalizeStackTrace(stackTrace)
-		fingerprint := HashFingerprint(normalized)
 
 		if failedTest.HistoricalContext == nil {
 			failedTest.HistoricalContext = &core.HistoricalContext{}
 		}
-		failedTest.HistoricalContext.ErrorFingerprint = fingerprint
-
-		if s.repo != nil {
-			s.repo.UpsertErrorFingerprint(ctx, fingerprint, normalized, report.Timestamp)
-		}
+		failedTest.HistoricalContext.ErrorFingerprint = HashFingerprint(normalized)
+		failedTest.NormalizedTrace = normalized
 	}
 }
 

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -122,6 +122,7 @@ type FailedTestInfo struct {
 	Severity            FailureSeverity   `json:"severity"`
 	HistoricalContext   *HistoricalContext `json:"historical_context,omitempty"`
 	CleanedRootCause    string            `json:"-"`
+	NormalizedTrace     string            `json:"-"`
 	IsCascade           bool              `json:"-"`
 	CascadeSourceTest   string            `json:"-"`
 }
@@ -154,7 +155,7 @@ type ReportRepository interface {
 	GetByID(ctx context.Context, id string) (*TestReport, error)
 	GetByTimeRange(ctx context.Context, start, end time.Time) ([]*TestReport, error)
 	GetFailureHistory(ctx context.Context, testName string, limit int) ([]*TestReport, error)
-	GetTestFailureCounts(ctx context.Context, testName string, since time.Time) (int, error)
+	GetTestFailureCounts(ctx context.Context, testName string, since time.Time, excludeReportID string) (int, error)
 	GetTestLastSuccess(ctx context.Context, testName string) (time.Time, error)
 	UpsertErrorFingerprint(ctx context.Context, fingerprint string, normalizedTrace string, timestamp time.Time) error
 	GetErrorFingerprint(ctx context.Context, fingerprint string) (int, time.Time, time.Time, error)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -232,11 +232,11 @@ func (r *ReportRepository) Delete(ctx context.Context, id string) error {
 	return tx.Commit()
 }
 
-func (r *ReportRepository) GetTestFailureCounts(ctx context.Context, testName string, since time.Time) (int, error) {
+func (r *ReportRepository) GetTestFailureCounts(ctx context.Context, testName string, since time.Time, excludeReportID string) (int, error) {
 	var count int
 	err := r.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM test_failures WHERE test_name = ? AND timestamp >= ?`,
-		testName, since,
+		`SELECT COUNT(*) FROM test_failures WHERE test_name = ? AND timestamp >= ? AND report_id != ?`,
+		testName, since, excludeReportID,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count test failures: %w", err)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -125,10 +125,10 @@ func (m *mockRepo) GetFailureHistory(ctx context.Context, testName string, limit
 	return results, nil
 }
 
-func (m *mockRepo) GetTestFailureCounts(ctx context.Context, testName string, since time.Time) (int, error) {
+func (m *mockRepo) GetTestFailureCounts(ctx context.Context, testName string, since time.Time, excludeReportID string) (int, error) {
 	count := 0
 	for _, r := range m.storedReports {
-		if r.Timestamp.Before(since) {
+		if r.Timestamp.Before(since) || r.ID == excludeReportID {
 			continue
 		}
 		for _, s := range r.Suites {

--- a/internal/parser/junit_parser.go
+++ b/internal/parser/junit_parser.go
@@ -116,7 +116,21 @@ func (p *JUnitParser) ParseStream(reader io.Reader) (*core.TestReport, error) {
 
 	report.Passed = report.TotalTests - report.Failed - report.Errored - report.Skipped
 
+	if latest := latestSuiteTimestamp(report.Suites); !latest.IsZero() {
+		report.Timestamp = latest
+	}
+
 	return report, nil
+}
+
+func latestSuiteTimestamp(suites []core.TestSuite) time.Time {
+	var latest time.Time
+	for _, suite := range suites {
+		if suite.Timestamp.After(latest) {
+			latest = suite.Timestamp
+		}
+	}
+	return latest
 }
 
 func (p *JUnitParser) convertSuite(raw junitTestSuite) core.TestSuite {
@@ -131,11 +145,7 @@ func (p *JUnitParser) convertSuite(raw junitTestSuite) core.TestSuite {
 		Cases:    make([]core.TestCase, 0, len(raw.Cases)),
 	}
 
-	if raw.Timestamp != "" {
-		if ts, err := time.Parse("2006-01-02T15:04:05", raw.Timestamp); err == nil {
-			suite.Timestamp = ts
-		}
-	}
+	suite.Timestamp = parseSuiteTimestamp(raw.Timestamp)
 
 	for _, rawCase := range raw.Cases {
 		suite.Cases = append(suite.Cases, p.convertCase(rawCase))
@@ -175,6 +185,24 @@ func (p *JUnitParser) convertCase(raw junitTestCase) core.TestCase {
 	}
 
 	return tc
+}
+
+var suiteTimestampLayouts = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+}
+
+func parseSuiteTimestamp(raw string) time.Time {
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range suiteTimestampLayouts {
+		if ts, err := time.Parse(layout, raw); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
 }
 
 func parseDuration(raw string) time.Duration {

--- a/internal/parser/junit_parser_test.go
+++ b/internal/parser/junit_parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"testing"
+	"time"
 
 	"sift/internal/core"
 )
@@ -172,6 +173,72 @@ func TestParseDuration(t *testing.T) {
 	addCase := report.Suites[0].Cases[0]
 	if addCase.Duration.Seconds() != 0.3 {
 		t.Errorf("expected case duration 0.3s, got %v", addCase.Duration)
+	}
+}
+
+func TestParseSuiteTimestampSetsReportTimestamp(t *testing.T) {
+	p := NewJUnitParser()
+
+	xml := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" timestamp="2026-06-28T10:00:00">
+    <testcase name="t1" classname="C" time="0.1"/>
+  </testsuite>
+  <testsuite name="B" tests="1" timestamp="2026-06-29T11:30:00">
+    <testcase name="t2" classname="C" time="0.1"/>
+  </testsuite>
+</testsuites>`)
+
+	report, err := p.Parse(xml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := time.Date(2026, 6, 29, 11, 30, 0, 0, time.UTC)
+	if !report.Timestamp.Equal(want) {
+		t.Errorf("expected report timestamp %v, got %v", want, report.Timestamp)
+	}
+}
+
+func TestParseSuiteTimestampLayouts(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Time
+	}{
+		{"2026-06-28T10:00:00", time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)},
+		{"2026-06-28T10:00:00Z", time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)},
+		{"2026-06-28T10:00:00+02:00", time.Date(2026, 6, 28, 8, 0, 0, 0, time.UTC)},
+		{"2026-06-28T10:00:00.123456", time.Date(2026, 6, 28, 10, 0, 0, 123456000, time.UTC)},
+		{"2026-06-28 10:00:00", time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tc := range tests {
+		got := parseSuiteTimestamp(tc.input)
+		if !got.Equal(tc.want) {
+			t.Errorf("parseSuiteTimestamp(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+
+	if !parseSuiteTimestamp("").IsZero() {
+		t.Error("expected zero time for empty input")
+	}
+	if !parseSuiteTimestamp("garbage").IsZero() {
+		t.Error("expected zero time for unparseable input")
+	}
+}
+
+func TestParseWithoutSuiteTimestampFallsBackToNow(t *testing.T) {
+	p := NewJUnitParser()
+
+	before := time.Now()
+	report, err := p.Parse(singleSuiteXML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now()
+
+	if report.Timestamp.Before(before) || report.Timestamp.After(after) {
+		t.Errorf("expected timestamp near now, got %v", report.Timestamp)
 	}
 }
 

--- a/internal/server/factory.go
+++ b/internal/server/factory.go
@@ -25,7 +25,7 @@ func (f *Factory) CreateAnalysisPipeline(repo core.ReportRepository) *analysis.P
 	return analysis.NewPipeline(
 		stages.NewExtractFailuresStage(),
 		stages.NewRootCauseExtractStage(),
-		stages.NewFingerprintStage(repo),
+		stages.NewFingerprintStage(),
 		stages.NewEnrichHistoryStage(repo),
 		stages.NewCascadeDetectStage(),
 		stages.NewSummarizeStage(repo),


### PR DESCRIPTION
- **fix: derive report timestamp from JUnit suite timestamps**
- **fix: exclude current report from failure history stats**
