### PR TITLE
Notification Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,7 @@ jintelligence
 *.db-shm
 *.db-wal
 
-# Claude Code
-.claude/
-.mcp.json
-
 # Development artifacts
-prompt.xml
 PRD.md
 cbioportal/
 demo/

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -33,11 +33,13 @@ func (h *Handler) RegisterTool(tool Tool, handler ToolFunc) {
 }
 
 func (h *Handler) Handle(ctx context.Context, req *Request) *Response {
+	if req.IsNotification() {
+		return nil
+	}
+
 	switch req.Method {
 	case "initialize":
 		return h.handleInitialize(req)
-	case "initialized":
-		return h.handleInitialized(req)
 	case "tools/list":
 		return h.handleToolsList(req)
 	case "tools/call":
@@ -68,14 +70,6 @@ func (h *Handler) handleInitialize(req *Request) *Response {
 	return &Response{
 		JSONRPC: "2.0",
 		Result:  result,
-		ID:      req.ID,
-	}
-}
-
-func (h *Handler) handleInitialized(req *Request) *Response {
-	return &Response{
-		JSONRPC: "2.0",
-		Result:  struct{}{},
 		ID:      req.ID,
 	}
 }

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func newTestHandler() *Handler {
+	return NewHandler(false)
+}
+
+func TestHandleNotificationReturnsNoResponse(t *testing.T) {
+	h := newTestHandler()
+
+	resp := h.Handle(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+
+	if resp != nil {
+		t.Fatalf("expected no response to notification, got %+v", resp)
+	}
+}
+
+func TestHandleUnknownNotificationReturnsNoResponse(t *testing.T) {
+	h := newTestHandler()
+
+	resp := h.Handle(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/cancelled",
+	})
+
+	if resp != nil {
+		t.Fatalf("expected no response to unknown notification, got %+v", resp)
+	}
+}
+
+func TestHandleRequestWithIDReturnsResponse(t *testing.T) {
+	h := newTestHandler()
+
+	resp := h.Handle(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "ping",
+		ID:      float64(1),
+	})
+
+	if resp == nil {
+		t.Fatal("expected response to ping request, got nil")
+	}
+	if resp.ID != float64(1) {
+		t.Errorf("expected response ID 1, got %v", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Errorf("expected no error, got %+v", resp.Error)
+	}
+}
+
+func TestHandleUnknownMethodWithIDReturnsError(t *testing.T) {
+	h := newTestHandler()
+
+	resp := h.Handle(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "does/not/exist",
+		ID:      float64(2),
+	})
+
+	if resp == nil {
+		t.Fatal("expected error response, got nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error in response, got none")
+	}
+	if resp.Error.Code != ErrorMethodNotFound {
+		t.Errorf("expected error code %d, got %d", ErrorMethodNotFound, resp.Error.Code)
+	}
+}
+
+func TestHandleInitializeReturnsServerInfo(t *testing.T) {
+	h := newTestHandler()
+
+	resp := h.Handle(context.Background(), &Request{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		ID:      float64(3),
+	})
+
+	if resp == nil {
+		t.Fatal("expected response to initialize, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("expected no error, got %+v", resp.Error)
+	}
+	result, ok := resp.Result.(InitializeResult)
+	if !ok {
+		t.Fatalf("expected InitializeResult, got %T", resp.Result)
+	}
+	if result.ServerInfo.Name != ServerName {
+		t.Errorf("expected server name %q, got %q", ServerName, result.ServerInfo.Name)
+	}
+}
+
+func TestIsNotification(t *testing.T) {
+	withID := &Request{JSONRPC: "2.0", Method: "ping", ID: float64(1)}
+	if withID.IsNotification() {
+		t.Error("request with ID should not be a notification")
+	}
+
+	withoutID := &Request{JSONRPC: "2.0", Method: "notifications/initialized"}
+	if !withoutID.IsNotification() {
+		t.Error("request without ID should be a notification")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -109,7 +109,9 @@ func (s *Server) serveStdio(ctx context.Context) error {
 			}
 
 			resp := s.handler.Handle(ctx, &req)
-			s.writeResponse(writer, resp)
+			if resp != nil {
+				s.writeResponse(writer, resp)
+			}
 		}
 	}
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -9,6 +9,10 @@ type Request struct {
 	ID      interface{}     `json:"id"`
 }
 
+func (r *Request) IsNotification() bool {
+	return r.ID == nil
+}
+
 type Response struct {
 	JSONRPC string      `json:"jsonrpc"`
 	Result  interface{} `json:"result,omitempty"`


### PR DESCRIPTION
## Summary
The MCP server was replying to JSON-RPC notifications, which the spec forbids, and sent a "Method not found" error in response to the standard 'notifications/initialized' message every client sends after the handshake.

## Context / Why It Matters
Claude code tolerates the stray response, so the bug was invisible during day to day use. Stricter MCP clients can log protocol errors, hang waiting on state, or drop the connection when a server responds to a notification. This matters most for anyone using sift with an MCP client other than claude code. 

## Details
**Steps to reproduce:**
1. Build the server and start it on stdio
2. Send an 'initialize' request, then the 'notifications/initialized' notification, then a 'tools/list' request
3. Count the responses on stdout

**Expected:** Two responses, one for each request with an `id`. Nothing for the notification.
**Actual:** Three responses, The middle one is a `-32601 Method not found` error replying to the notification, which violates JSON-RPC 2.0
**Environment:** Any MCP client over Stdio transport. Reproduced with a scripted stdin session against the built binary.

**Proposed solution:**
- `Request.IsNotification()` on the request type: a message with no `id` is a notification per the spec                                                                                                                                                                 
- `Handle` returns nil for notifications before hitting the method switch, so the rule covers all notifications by shape rather than by method name                                                                                                                                       
-  The stdio loop only writes a response when the handler returned one                                                                                                                                                                                                                    
- Removed the old `initialized` case and its handler. The real method name is `notifications/initialized`, and responding to it was wrong anyway                                                                                                                                           
-  The parse-error path still responds with `id: null`, which is what the spec requires when a message is too malformed to read its id    

## Acceptance Criteria 
                                                                                                                                                                                                                                                  
- [x] Notifications (`notifications/initialized`, `notifications/cancelled`, unknown ones) get no response                                                                                                                                                                                
- [x]  Requests with an `id` still get responses carrying that `id`                                                                                                                                                                                                                        
- [x] Unknown *request* methods still return a proper Method-not-found error                                                                                                                                                                                                              
- [x]  `initialize` handshake unchanged                                                                                                                                                                                                                                                   
- [x] Covered by six new tests in `handler_test.go`; manual stdio session confirms two responses for two requests and silence for the notification 